### PR TITLE
fix list len for last item assignment

### DIFF
--- a/movern_sensitivity_driver_generation.py
+++ b/movern_sensitivity_driver_generation.py
@@ -80,7 +80,7 @@ def movern_sensitivty_driver_generation():
                     lines[6] = str(msl)+'\n'
                     lines[7] = str(sigma)+'\n'
                     lines[11]= str(tn)+'\n'
-                    lines[17]= str(skip)+'\n'
+                    lines[len(lines) -1]= str(skip)+'\n'
                     
                     print lines
                     


### PR DESCRIPTION
This driver was erroring because the last item assigned was 17, but index 17 doesn't exist because list index starts at 0. (16 is the last index assignment available.) 